### PR TITLE
Add leading slash to RewritePath example

### DIFF
--- a/modules/spring-cloud-gateway/pages/gatewayfilter-factories/the-rewritepath-gatewayfilter-factory.adoc
+++ b/modules/spring-cloud-gateway/pages/gatewayfilter-factories/the-rewritepath-gatewayfilter-factory.adoc
@@ -19,7 +19,7 @@ spring:
         predicates:
         - Path=/foo/**
         filters:
-        - RewritePath=/red(?<segment>/?.*), $\{segment}
+        - RewritePath=/red(?<segment>/?.*), /$\{segment}
 ----
 ====
 


### PR DESCRIPTION
When accessing the root element `/red` without a trailing slash this would result in a
> java.lang.IllegalArgumentException: The path does not have a leading slash.

Adding the leading slash in the removes this error